### PR TITLE
Set firstsetup session as default for new users

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -58,6 +58,12 @@ modules:
     - modules/210-libs-extra
     - modules/999-pkg-cleanup
 
+- name: firstsetup-default-session
+  type: shell
+  commands:
+  - sed 's/Session=/Session=firstsetup/g' -i /usr/share/accountsservice/user-templates/administrator
+  - sed 's/Session=/Session=firstsetup/g' -i /usr/share/accountsservice/user-templates/standard
+
 - name: cleanup
   type: shell
   commands:


### PR DESCRIPTION
Adds a step in the vib recipe to modify `/usr/share/accountsservice/user-templates/{administrator,standard}` to contain `Session=firstsetup`, setting the first setup session as a default for every new user.

This is requires another PR in first-setup, which has not been opened yet, and can only be merged once the PR in first-setup is merged to ensure everything works correctly.

Fixes https://github.com/Vanilla-OS/first-setup/issues/197