### PR TITLE
Add waydroid configuration files

### DIFF
--- a/includes.container/etc/vso/fdroid.toml
+++ b/includes.container/etc/vso/fdroid.toml
@@ -1,0 +1,6 @@
+Name = "FDroid"
+Key = "43238D512C1E5EB2D6569F4A3AFBF5523418B82E0A3ED1552770ABB9A9C9CCAB"
+IndexURL = "https://f-droid.org/repo/index-v2.json"
+RepoURL = "https://f-droid.org/repo/"
+PackageURL = "https://f-droid.org/repo/%s"
+PackageInfoURL = "https://f-droid.org/api/v1/packages/%s"

--- a/includes.container/etc/vso/izzyondroid.toml
+++ b/includes.container/etc/vso/izzyondroid.toml
@@ -1,0 +1,6 @@
+Name = "izzyondroid"
+Key = "fingerprint=3BF0D6ABFEAE2F401707B6D966BE743BF0EEE49C2561B9BA39073711F628937A"
+IndexURL = "https://apt.izzysoft.de/fdroid/repo/index-v2.json"
+RepoURL = "https://apt.izzysoft.de/fdroid/repo/"
+PackageURL = "https://apt.izzysoft.de/fdroid/repo/%s"
+PackageInfoURL = "https://apt.izzysoft.de/fdroid/api/v1/packages/%s"

--- a/includes.container/usr/share/vso/apx/stacks/vso-waydroid.yaml
+++ b/includes.container/usr/share/vso/apx/stacks/vso-waydroid.yaml
@@ -1,0 +1,5 @@
+name: vso-waydroid
+base: ghcr.io/vanilla-os/waydroid:main
+packages: []
+pkgmanager: apt
+builtin: true


### PR DESCRIPTION
Adds the waydroid configuration files for vanilla-system-operator to ensure that users are able to use the waydroid integration properly.

This currently only adds the files directly through `includes.container`, but we should consider changing this to be automated through a module in the future.