### PR TITLE
cleanup: rearrange packages, add libblockdev-crypto3

### DIFF
--- a/modules/00-vanilla-apx-gui.yml
+++ b/modules/00-vanilla-apx-gui.yml
@@ -10,7 +10,7 @@ modules:
   type: apt
   source:
     packages:
-    - meson
     - build-essential
-    - libadwaita-1-dev
     - gettext
+    - libadwaita-1-dev
+    - meson

--- a/modules/00-vanilla-desktop-base.yml
+++ b/modules/00-vanilla-desktop-base.yml
@@ -16,3 +16,4 @@ modules:
     - dpkg-dev
     - dh-make
     - librsvg2-bin
+    - optipng

--- a/modules/00-vanilla-desktop-base.yml
+++ b/modules/00-vanilla-desktop-base.yml
@@ -12,9 +12,7 @@ modules:
   type: apt
   source:
     packages:
+    - build-essential
     - dpkg-dev
     - dh-make
-    - build-essential
-    - inkscape
     - librsvg2-bin
-    - optipng

--- a/modules/00-vanilla-first-setup.yml
+++ b/modules/00-vanilla-first-setup.yml
@@ -12,19 +12,19 @@ modules:
   type: apt
   source:
     packages:
-    - dpkg-dev
     - build-essential
     - debhelper
-    - python3
-    - meson
-    - libadwaita-1-dev
-    - gettext
     - desktop-file-utils
-    - make
+    - dpkg-dev
+    - gettext
+    - gir1.2-nma4-1.0
+    - libadwaita-1-dev
     - libjpeg-dev
     - libnm0
+    - libnm-dev
     - libnma0
     - libnma-gtk4-0
-    - gir1.2-nma4-1.0
-    - libnm-dev
     - libnma-gtk4-dev
+    - make
+    - meson
+    - python3

--- a/modules/00-vanilla-system-operator.yml
+++ b/modules/00-vanilla-system-operator.yml
@@ -36,13 +36,13 @@ modules:
     type: apt
     source:
       packages:
-      - dpkg-dev
       - build-essential
       - debhelper
-      - python3
-      - meson
-      - libadwaita-1-dev
-      - gettext
-      - make
       - desktop-file-utils
+      - dpkg-dev
+      - gettext
+      - libadwaita-1-dev
       - libjpeg-dev
+      - make
+      - meson
+      - python3

--- a/modules/100-accessibility.yml
+++ b/modules/100-accessibility.yml
@@ -2,11 +2,11 @@ name: accessibility
 type: apt
 source:
   packages:
-  - orca
+  - at-spi2-core
   - brltty
   - espeak-ng
-  - at-spi2-core
   - mousetweaks
+  - orca
   
   - speech-dispatcher
   - speech-dispatcher-espeak-ng

--- a/modules/110-fonts.yml
+++ b/modules/110-fonts.yml
@@ -5,7 +5,6 @@ source:
   - fonts-cantarell
   - fonts-dejavu-core
   - fonts-freefont-ttf
-  - fonts-noto-color-emoji
   - fonts-indic
   - fonts-kacst-one
   - fonts-khmeros
@@ -13,6 +12,7 @@ source:
   - fonts-liberation
   - fonts-lklug-sinhala
   - fonts-noto-cjk
+  - fonts-noto-color-emoji
   - fonts-sil-abyssinica
   - fonts-sil-padauk
   - fonts-thai-tlwg

--- a/modules/120-network.yml
+++ b/modules/120-network.yml
@@ -3,10 +3,10 @@ type: apt
 source:
   packages:
   - network-manager-gnome
-  - network-manager-openvpn-gnome
   - network-manager-fortisslvpn-gnome
   - network-manager-l2tp-gnome
   - network-manager-openconnect-gnome
+  - network-manager-openvpn-gnome
   - network-manager-ssh-gnome
   - network-manager-vpnc-gnome
 

--- a/modules/140-password.yml
+++ b/modules/140-password.yml
@@ -2,6 +2,6 @@ name: password
 type: apt
 source:
   packages:
-  - gnome-keyring
   - cracklib-runtime
+  - gnome-keyring
   - ssh-askpass-gnome

--- a/modules/160-utilities.yml
+++ b/modules/160-utilities.yml
@@ -2,10 +2,11 @@ name: utilities
 type: apt
 source:
   packages:
+  - adwdialog
   - gnome-disk-utility
   - gnome-system-monitor
   - gnome-sushi
   - gnome-software
   - ghostscript
+  - optipng
   - zenity
-  - adwdialog

--- a/modules/160-utilities.yml
+++ b/modules/160-utilities.yml
@@ -8,5 +8,4 @@ source:
   - gnome-sushi
   - gnome-software
   - ghostscript
-  - optipng
   - zenity

--- a/modules/20-gnome-core.yml
+++ b/modules/20-gnome-core.yml
@@ -5,14 +5,14 @@ source:
   - gdm3
   - xorg
 
+  - gnome-session
   - gnome-shell
   - gnome-shell-extensions
-  - gnome-session
   - gnome-browser-connector
 
-  - xdg-desktop-portal-gnome
-  - evolution-data-server
-  - mutter
-  - gjs
-  - geoclue-2.0
   - dbus-x11
+  - evolution-data-server
+  - geoclue-2.0
+  - gjs
+  - mutter
+  - xdg-desktop-portal-gnome

--- a/modules/20-gnome-core.yml
+++ b/modules/20-gnome-core.yml
@@ -15,4 +15,6 @@ source:
   - geoclue-2.0
   - gjs
   - mutter
+  - xdg-desktop-portal
   - xdg-desktop-portal-gnome
+  - xdg-desktop-portal-gtk

--- a/modules/200-gnome-common.yml
+++ b/modules/200-gnome-common.yml
@@ -6,6 +6,6 @@ source:
   - heif-thumbnailer
 
   - gnome-user-docs
-  - webp-pixbuf-loader
   - rygel
+  - webp-pixbuf-loader
   - yelp

--- a/modules/210-libs-extra.yml
+++ b/modules/210-libs-extra.yml
@@ -12,7 +12,7 @@ source:
 
   - libgdk-pixbuf2.0-bin
   - libglib2.0-bin
-  - libblockdev-crypto2
+  - libblockdev-crypto3
   - libpam-gnome-keyring
   - libproxy1-plugin-gsettings
   - libwmf0.2-7-gtk

--- a/modules/210-libs-extra.yml
+++ b/modules/210-libs-extra.yml
@@ -10,8 +10,9 @@ source:
   - ibus-gtk3
   - ibus-gtk4
 
+  - libgdk-pixbuf2.0-bin
   - libglib2.0-bin
+  - libblockdev-crypto2
   - libpam-gnome-keyring
   - libproxy1-plugin-gsettings
   - libwmf0.2-7-gtk
-  - libgdk-pixbuf2.0-bin

--- a/modules/30-gnome-essentials.yml
+++ b/modules/30-gnome-essentials.yml
@@ -5,9 +5,9 @@ source:
   - nautilus
   - nautilus-share
 
-  - gnome-console
   - gnome-bluetooth
-  - gnome-online-accounts
-  - gnome-menus
   - gnome-color-manager
+  - gnome-console
   - gnome-control-center
+  - gnome-menus
+  - gnome-online-accounts

--- a/modules/40-gnome-appearance.yml
+++ b/modules/40-gnome-appearance.yml
@@ -3,7 +3,7 @@ type: apt
 source:
   packages:
   - adwaita-icon-theme
-  
+
+  - gnome-accessibility-themes
   - gnome-backgrounds
   - gnome-themes-extra
-  - gnome-accessibility-themes

--- a/modules/60-media.yml
+++ b/modules/60-media.yml
@@ -5,6 +5,6 @@ source:
   - ffmpeg
 
   - gstreamer1.0-alsa
+  - gstreamer1.0-libav
   - gstreamer1.0-plugins-base-apps
   - gstreamer1.0-pulseaudio
-  - gstreamer1.0-libav

--- a/modules/90-3d-utils.yml
+++ b/modules/90-3d-utils.yml
@@ -2,9 +2,9 @@ name: 3d-utils
 type: apt
 source:
   packages:
-  - steam-devices
-
-  - mesa-vulkan-drivers
   - mesa-vdpau-drivers
+  - mesa-vulkan-drivers
+
+  - steam-devices
 
   - vdpau-driver-all


### PR DESCRIPTION
## Changes

- Rearrange packages in alphabetical order.
- Add `libblockdev-crypto3` to libs-extra for LUKS (decryption) as suggested by @axtloss.
- ~Move `optipng` from the desktop base to the utilities module.~ (Edit. Reverted this change after failing CI, seems like we use it to optimize first setup assets)
- Remove `inkscape` from the desktop base as suggested by @taukakao.