### PR TITLE
Fix: use custom fsguard config to account for .system

### DIFF
--- a/includes.container/fsguard_config.patch
+++ b/includes.container/fsguard_config.patch
@@ -1,0 +1,12 @@
+diff --git a/config/config.go b/config/config.go
+index 35291d7..1dda59d 100644
+--- a/config/config.go
++++ b/config/config.go
+@@ -1,6 +1,6 @@
+ package config
+ 
+-var FileListPath = "/FsGuard/filelist"
++var FileListPath = "/.system/FsGuard/filelist"
+ var InitLocation = "/usr/bin/init"
+ var PostInitExec = "/usr/lib/systemd/systemd"
+ var RunPostInit = true

--- a/recipe.yml
+++ b/recipe.yml
@@ -74,6 +74,24 @@ modules:
   commands:
   - rm /usr/lib/*/gnome-software/plugins-20/libgs_plugin_packagekit.so
 
+- name: build-fsguard
+  type: go
+  source:
+    type: git
+    url: https://github.com/linux-immutability-tools/FsGuard
+    tag: v0.1.2
+  modules:
+    - name: install go
+      type: apt
+      source:
+        packages:
+          - golang
+    - name: config-patch
+      type: shell
+      commands:
+        - patch -u /sources/build-fsguard/config/config.go -i /fsguard_config.patch
+        - rm /fsguard_config.patch
+
 - name: cleanup
   type: shell
   commands:
@@ -83,10 +101,15 @@ modules:
 
 - name: fsguard
   type: fsguard
+  CustomFsGuard: true
   FsGuardLocation: "/usr/sbin/FsGuard"
   GenerateKey: true
   FilelistPaths: ["/usr/bin"]
   modules:
+    - name: install-built-fsguard
+      type: shell
+      commands:
+        - cp /sources/build-fsguard/build-fsguard /sources/FsGuard
     - name: remove-prev-fsguard
       type: shell
       commands:


### PR DESCRIPTION
Uses a custom FsGuard configuration file to account for the fact that /FsGuard is in /.system/