### PR TITLE
feat: Add custom gnome control center

### DIFF
--- a/modules/20-gnome-core.yml
+++ b/modules/20-gnome-core.yml
@@ -18,3 +18,15 @@ source:
   - xdg-desktop-portal
   - xdg-desktop-portal-gnome
   - xdg-desktop-portal-gtk
+modules:
+  name: gnome-control-center
+  type: dpkg
+  source:
+    type: tar
+    url: https://github.com/Vanilla-OS/gnome-control-center/releases/download/continuous/gnome-control-center.tar.xz
+    checksum: 81eff2e3fa32a918902cf49cd07d5bf43db0b3bcfef0ce80b78e7f2494bfd060
+  name: remove-dbgsym
+  type: shell 
+  commands:
+    - apt remove -y gnome-control-center-dbgsym gnome-control-center-dev
+


### PR DESCRIPTION
Adds the custom gnome control center build from https://github.com/Vanilla-OS/gnome-control-center