### PR TITLE
fix: remove ld preload step

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -19,7 +19,6 @@ modules:
   - apt clean
   - apt-mark hold snapd gnome-software-plugin-snap
   - apt -y install squashfs-tools minisign
-  - mv /etc/ld.so.preload /ld.so.preload
 
 - name: vanilla-tools
   type: shell


### PR DESCRIPTION
This command would fail with https://github.com/Vanilla-OS/core-image/pull/26 which is why it needs to be removed to ensure builds still complete successfully 