### PR TITLE
fix:[close #66] Reduce shutdown delay

### DIFF
--- a/includes.container/usr/lib/systemd/system/user@.service
+++ b/includes.container/usr/lib/systemd/system/user@.service
@@ -1,0 +1,31 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=User Manager for UID %i
+Documentation=man:user@.service(5)
+After=user-runtime-dir@%i.service dbus.service systemd-oomd.service
+Requires=user-runtime-dir@%i.service
+IgnoreOnIsolate=yes
+
+[Service]
+User=%i
+PAMName=systemd-user
+Type=notify-reload
+ExecStart=/usr/lib/systemd/systemd --user
+Slice=user-%i.slice
+KillMode=mixed
+Delegate=pids memory cpu
+DelegateSubgroup=init.scope
+TasksMax=infinity
+TimeoutStopSec=60s
+KeyringMode=inherit
+OOMScoreAdjust=100
+MemoryPressureWatch=skip
+


### PR DESCRIPTION
This PR attempts to fix #66 by reducing the Systemd timeout from 120s to 60s. This may not look like a proper solution, but it's exactly what SIlverblue did a while back when they had this issue so...