### PR TITLE
reverts "fix[close #68]: Remove the default password"

### DIFF
--- a/includes.container/usr/share/glib-2.0/schemas/90-vanilla-os-lock.gschema.override
+++ b/includes.container/usr/share/glib-2.0/schemas/90-vanilla-os-lock.gschema.override
@@ -1,4 +1,0 @@
-[org.gnome.desktop.screensaver]
-lock-enabled=false
-[org.gnome.desktop.lockdown]
-disable-lock-screen=true


### PR DESCRIPTION
The commit was not only removing the lock screen for the vanilla user. Instead, it was removing the lock screen for all users.

This should be reverted since it's causing #82 

Closes #82 
Reopens #68 

A better solution for #68 would probably require setting it only for the vanilla user or only setting it through the installer.