### PR TITLE
chore: bump Vib action to v0.6.2

### DIFF
--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: vanilla-os/vib-gh-action@v0.3.3-1
+    - uses: vanilla-os/vib-gh-action@v0.6.2
       with:
         recipe: 'recipe.yml'
-        plugins: 'Vanilla-OS/vib-fsguard:v1.2-1'
+        plugins: 'Vanilla-OS/vib-fsguard:v1.3-2'
 
     - name: Build the Docker image
       run: docker image build -f Containerfile --tag ghcr.io/vanilla-os/desktop:main .

--- a/.github/workflows/vib-pr.yml
+++ b/.github/workflows/vib-pr.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    - uses: vanilla-os/vib-gh-action@v0.3.3-1
+  
+    - uses: vanilla-os/vib-gh-action@v0.6.2
       with:
         recipe: 'recipe.yml'
-        plugins: 'Vanilla-OS/vib-fsguard:v1.2-1'
+        plugins: 'Vanilla-OS/vib-fsguard:v1.3-2'
 
     - name: Build the Docker image
       run: docker image build -f Containerfile --tag vanillaos/desktop .

--- a/recipe.yml
+++ b/recipe.yml
@@ -1,116 +1,120 @@
-base: ghcr.io/vanilla-os/core:main
 name: Vanilla Desktop
 id: vanilla-desktop
-labels:
-  maintainer: Vanilla OS Contributors
-args:
-  DEBIAN_FRONTEND: noninteractive
-runs:
-- echo 'APT::Install-Recommends "1";' > /etc/apt/apt.conf.d/01norecommends
 
-modules:
-- name: init-setup
-  type: shell
-  commands:
-  - echo 'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"' > /etc/environment
-  - sed -i '4,10d' /etc/profile
-  - apt update
-  - apt upgrade -y
-  - apt clean
-  - apt-mark hold snapd gnome-software-plugin-snap
-  - apt -y install squashfs-tools minisign
+stages:
+- id: build
+  base: ghcr.io/vanilla-os/core:main
+  singlelayer: false
+  labels:
+    maintainer: Vanilla OS Contributors
+  args:
+    DEBIAN_FRONTEND: noninteractive
+  runs:
+  - echo 'APT::Install-Recommends "1";' > /etc/apt/apt.conf.d/01norecommends
 
-- name: vanilla-tools
-  type: shell
-  source:
-    type: tar
-    # switch to production build once in production
-    url: https://github.com/Vanilla-OS/vanilla-tools/releases/download/continuous/vanilla-tools.tar.gz
-  commands:
-  - mkdir -p /usr/bin
-  - cp /sources/vanilla-tools/lpkg /usr/bin/lpkg
-  - cp /sources/vanilla-tools/cur-gpu /usr/bin/cur-gpu
-  - chmod +x /usr/bin/lpkg
-  - chmod +x /usr/bin/cur-gpu
-
-- name: packages-modules
-  type: includes
-  includes:
-    - modules/00-vanilla-desktop-base
-    - modules/00-vanilla-backgrounds
-    - modules/00-vanilla-first-setup
-    - modules/00-vanilla-gnome-default-settings
-    - modules/00-vanilla-system-operator
-    - modules/00-vanilla-apx-gui
-    - modules/00-vanilla-tour
-    - modules/00-vanilla-sideload
-    - modules/00-vanilla-updates-utility
-    - modules/02-waydroid-modules
-    - modules/03-fswarn
-    - modules/10-vanilla-abroot-rollback-notifier
-    - modules/20-gnome-core
-    - modules/21-gnome-control-center
-    - modules/22-gnome-console
-    - modules/30-gnome-essentials
-    - modules/40-gnome-appearance
-    - modules/50-laptop-goodies
-    - modules/60-media
-    - modules/80-printers
-    - modules/90-3d-utils
-    - modules/100-accessibility
-    - modules/110-fonts
-    - modules/120-network
-    - modules/130-plymouth
-    - modules/131-plymouth-theme-vanilla
-    - modules/140-password
-    - modules/160-utilities
-    - modules/170-gnome-software-vso-plugin
-    - modules/200-gnome-common
-    - modules/210-libs-extra
-    - modules/211-abroot-fstab-mount
-    - modules/998-vanilla-cleanup
-    - modules/999-pkg-cleanup
-
-- name: firstsetup-default-session
-  type: shell
-  commands:
-  - sed 's/Session=/Session=firstsetup/g' -i /usr/share/accountsservice/user-templates/administrator
-  - sed 's/Session=/Session=firstsetup/g' -i /usr/share/accountsservice/user-templates/standard
-
-- name: gnome-software-setup
-  type: shell
-  commands:
-  - rm /usr/lib/*/gnome-software/plugins-20/libgs_plugin_packagekit.so
-
-- name: cleanup
-  type: shell
-  commands:
-  - apt autoremove -y
-  - apt clean
-  - lpkg --lock
-
-- name: sysconf-setup
-  type: shell
-  commands:
-    - rsync -a /etc/ /sysconf/
-
-- name: fsguard
-  type: fsguard
-  CustomFsGuard: false
-  FsGuardLocation: "/usr/sbin/FsGuard"
-  GenerateKey: true
-  FilelistPaths: ["/usr/bin"]
   modules:
-    - name: remove-prev-fsguard
-      type: shell
-      commands:
-        - rm -rf /FsGuard
-        - rm -f ./minisign.pub ./minisign.key
-        - chmod +x /usr/sbin/init
+  - name: init-setup
+    type: shell
+    commands:
+    - echo 'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"' > /etc/environment
+    - sed -i '4,10d' /etc/profile
+    - apt update
+    - apt upgrade -y
+    - apt clean
+    - apt-mark hold snapd gnome-software-plugin-snap
+    - apt -y install squashfs-tools minisign
 
-- name: cleanup2
-  type: shell
-  commands:
-    - rm -rf /tmp/*
-    - rm -rf /var/tmp/*
-    - rm -rf /sources
+  - name: vanilla-tools
+    type: shell
+    source:
+      type: tar
+      # switch to production build once in production
+      url: https://github.com/Vanilla-OS/vanilla-tools/releases/download/continuous/vanilla-tools.tar.gz
+    commands:
+    - mkdir -p /usr/bin
+    - cp /sources/vanilla-tools/lpkg /usr/bin/lpkg
+    - cp /sources/vanilla-tools/cur-gpu /usr/bin/cur-gpu
+    - chmod +x /usr/bin/lpkg
+    - chmod +x /usr/bin/cur-gpu
+
+  - name: packages-modules
+    type: includes
+    includes:
+      - modules/00-vanilla-desktop-base.yml
+      - modules/00-vanilla-backgrounds.yml
+      - modules/00-vanilla-first-setup.yml
+      - modules/00-vanilla-gnome-default-settings.yml
+      - modules/00-vanilla-system-operator.yml
+      - modules/00-vanilla-apx-gui.yml
+      - modules/00-vanilla-tour.yml
+      - modules/00-vanilla-sideload.yml
+      - modules/00-vanilla-updates-utility.yml
+      - modules/02-waydroid-modules.yml
+      - modules/03-fswarn.yml
+      - modules/10-vanilla-abroot-rollback-notifier.yml
+      - modules/20-gnome-core.yml
+      - modules/21-gnome-control-center.yml
+      - modules/22-gnome-console.yml
+      - modules/30-gnome-essentials.yml
+      - modules/40-gnome-appearance.yml
+      - modules/50-laptop-goodies.yml
+      - modules/60-media.yml
+      - modules/80-printers.yml
+      - modules/90-3d-utils.yml
+      - modules/100-accessibility.yml
+      - modules/110-fonts.yml
+      - modules/120-network.yml
+      - modules/130-plymouth.yml
+      - modules/131-plymouth-theme-vanilla.yml
+      - modules/140-password.yml
+      - modules/160-utilities.yml
+      - modules/170-gnome-software-vso-plugin.yml
+      - modules/200-gnome-common.yml
+      - modules/210-libs-extra.yml
+      - modules/211-abroot-fstab-mount.yml
+      - modules/998-vanilla-cleanup.yml
+      - modules/999-pkg-cleanup.yml
+
+  - name: firstsetup-default-session
+    type: shell
+    commands:
+    - sed 's/Session=/Session=firstsetup/g' -i /usr/share/accountsservice/user-templates/administrator
+    - sed 's/Session=/Session=firstsetup/g' -i /usr/share/accountsservice/user-templates/standard
+
+  - name: gnome-software-setup
+    type: shell
+    commands:
+    - rm /usr/lib/*/gnome-software/plugins-20/libgs_plugin_packagekit.so
+
+  - name: cleanup
+    type: shell
+    commands:
+    - apt autoremove -y
+    - apt clean
+    - lpkg --lock
+
+  - name: sysconf-setup
+    type: shell
+    commands:
+      - rsync -a /etc/ /sysconf/
+
+  - name: fsguard
+    type: fsguard
+    CustomFsGuard: false
+    FsGuardLocation: "/usr/sbin/FsGuard"
+    GenerateKey: true
+    FilelistPaths: ["/usr/bin"]
+    modules:
+      - name: remove-prev-fsguard
+        type: shell
+        commands:
+          - rm -rf /FsGuard
+          - rm -f ./minisign.pub ./minisign.key
+          - chmod +x /usr/sbin/init
+
+  - name: cleanup2
+    type: shell
+    commands:
+      - rm -rf /tmp/*
+      - rm -rf /var/tmp/*
+      - rm -rf /sources


### PR DESCRIPTION
## Changes

- Bump Vib action to `v0.6.2`.
- Update `recipe.yml` to new syntax.