### PR TITLE
runs systemd exec command in shell

### DIFF
--- a/includes.container/usr/lib/systemd/system/clear-first-setup-steps.service
+++ b/includes.container/usr/lib/systemd/system/clear-first-setup-steps.service
@@ -4,4 +4,4 @@ After=local-fs.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/echo "" > /etc/org.vanillaos.FirstSetup.commands
+ExecStart=/usr/bin/sh -c '/usr/bin/echo "" > /etc/org.vanillaos.FirstSetup.commands'


### PR DESCRIPTION
Systemd does not use a shell by default so it will not recognize the ">" operator.