### PR TITLE
Refactor shell script to enhance variable scoping and security

### DIFF
--- a/includes.container/usr/sbin/init
+++ b/includes.container/usr/sbin/init
@@ -2,23 +2,23 @@
 
 function failed() {
     /.system/usr/bin/plymouth quit
-    squashfs="/.system/boot/fswarn.squash"
+    local squashfs="/.system/boot/fswarn.squash"
     mount -t tmpfs -o rw,size=1G tmpfs /tmp
-    tmp="/tmp"
+    local tmp="/tmp"
     chmod 0755 "$tmp"
-    unsquashfs -q -L -follow -d /tmp /.system/boot/fswarn.squash
-    mount --rbind /dev $tmp/dev
+    unsquashfs -q -L -follow -d /tmp "$squashfs"
+    mount --rbind /dev "$tmp/dev"
 
-    resolution=$(chroot "$tmp" /bin/bash -c '/usr/sbin/fbset | /bin/grep "mode " | /bin/sed "s/\"//g" | /bin/sed "s/-0//g" | /usr/bin/gawk '\''BEGIN{FS=" "}; {print $2}'\''')
+    local resolution=$(chroot "$tmp" /bin/bash -c '/usr/sbin/fbset | /bin/grep "mode " | /bin/sed "s/\"//g" | /bin/sed "s/-0//g" | /usr/bin/gawk '\''BEGIN{FS=" "}; {print $2}'\''')
     clear
     tput cnorm
     echo -e "\033[1;0H"
-    chroot $tmp /bin/bash -c "convert -resize $resolution -background black -gravity center -extent $resolution /verification_failed.png bgra:/dev/fb0"
+    chroot "$tmp" /bin/bash -c "convert -resize $resolution -background black -gravity center -extent $resolution /verification_failed.png bgra:/dev/fb0"
     echo -e "\033[999;0H"
     read -sn1 input
     if [[ "$input" == "c" ]]; then
         echo -e "\033[1;0H"
-        chroot $tmp /bin/bash -c "convert -resize $resolution -background black -gravity center -extent $resolution /continue_confirm.png bgra:/dev/fb0"
+        chroot "$tmp" /bin/bash -c "convert -resize $resolution -background black -gravity center -extent $resolution /continue_confirm.png bgra:/dev/fb0"
         echo -e "\033[999;0H"
         read -sn1 input
         if [[ "$input" == "y" ]]; then
@@ -31,7 +31,7 @@ function failed() {
     fi
 }
 
-/usr/sbin/FsGuard verify /.system/FsGuard/filelist
+/usr/sbin/FsGuard verify "/.system/FsGuard/filelist"
 if [[ $? -ne 0 ]]; then
     failed
 fi


### PR DESCRIPTION
This commit improves the Bash script by introducing the following changes:

1. **Variable Scoping**: Variables within the `failed` function are now declared with `local`. This change confines their scope to the function itself, preventing them from affecting the global environment or interfering with other scripts that might source this file.

2. **Variable Quoting**: All variable expansions have been quoted properly. This enhancement prevents issues related to word splitting and globbing, which are common sources of bugs in shell scripts, especially when variables may contain spaces or special shell characters.

These modifications enhance the robustness, readability, and maintainability of the script, ensuring that it adheres to best practices for shell scripting. These changes are particularly crucial for scripts that handle important system functions and configuration settings, as they reduce the risk of unintended side effects and security vulnerabilities.