### PR TITLE
feat: add fwupd plugin for gnome-software

### DIFF
--- a/modules/160-utilities.yml
+++ b/modules/160-utilities.yml
@@ -10,3 +10,4 @@ source:
   - zenity
   - flatpak
   - gnome-software-plugin-flatpak
+  - gnome-software-plugin-fwupd


### PR DESCRIPTION
fwupd is installed so why not enable graphically installing firmware updates through gnome software. 