### PR TITLE
fix waydroid udev rules

### DIFF
--- a/includes.container/etc/udev/rules.d/99-waydroid.rules
+++ b/includes.container/etc/udev/rules.d/99-waydroid.rules
@@ -1,2 +1,2 @@
-KERNEL=="binder", NAME="%k", MODE="0666"
-KERNEL=="ashmem", NAMe="%k", MODE="0666"
+KERNEL=="binder", MODE="0666"
+KERNEL=="ashmem", MODE="0666"


### PR DESCRIPTION
The `NAME` parameter does not work for kernel module rules