### PR TITLE
fix: Show waydroid desktop entries

### DIFF
--- a/includes.container/usr/bin/waydroid
+++ b/includes.container/usr/bin/waydroid
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+
+if [[ -f /run/.containerenv ]]; then
+    /usr/bin/waydroid "$@"
+    exit
+fi
+
+if [[ "$1" == "app" ]]; then
+	/usr/bin/vso android launch "$3"
+fi
+


### PR DESCRIPTION
Adds a "fake" waydroid script to the host so that gnome shows the waydroid desktop entries