### PR TITLE
fix: use patched anbox-modules repo

### DIFF
--- a/modules/02-waydroid-modules.yml
+++ b/modules/02-waydroid-modules.yml
@@ -7,7 +7,7 @@ commands:
 - dkms install waydroid-ashmem/1 -k $(ls /usr/src | grep -Po '[0-9].[0-9].[0-9].*$' | head -1)
 source:
   type: git
-  url: https://github.com/choff/anbox-modules.git
+  url: https://github.com/Vanilla-OS/anbox-modules.git
   branch: master
   commit: latest
 modules:


### PR DESCRIPTION
A supposed fix for https://github.com/Vanilla-OS/vanilla-system-operator/issues/112. Uses `anbox-modules` compiled with `-fcf-protection=branch` option.