### PR TITLE
feat: Add drivers for some common printer models

### DIFF
--- a/modules/80-printers.yml
+++ b/modules/80-printers.yml
@@ -2,8 +2,14 @@ name: printers
 type: apt
 source:
   packages:
+  # General
   - cups
   - cups-pk-helper
 
+  - printer-driver-brlaser  # Brother
+  - printer-driver-escpr    # Epson
+  - hplip                   # HP
+
+  # Config
   - system-config-printer-common
   - system-config-printer-udev


### PR DESCRIPTION
Adds packages for Brother, Epson, and HP laser printers that are not part of CUPS.