### PR TITLE
feat: systemd unit for apx-vso-pico

### DIFF
--- a/includes.container/etc/systemd/user/apx-vso-pico.service
+++ b/includes.container/etc/systemd/user/apx-vso-pico.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=VSO Pico Container
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Environment=PODMAN_SYSTEMD_UNIT=%n
+Restart=on-failure
+TimeoutStopSec=10
+ExecStart=/.system/usr/bin/podman start apx-vso-pico
+ExecStop=/.system/usr/bin/podman stop  \
+	-t 5 apx-vso-pico
+ExecStopPost=/.system/usr/bin/podman stop  \
+	-t 5 apx-vso-pico
+Type=forking
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Adds a systemd unit for managing apx-vso-pico, which automatically starts the container on startup and shuts it down on poweroff. When enabled by the user (new installations should do by default with first-setup), this service avoids having to wait for the container to start when opening a terminal for the first time, as well as drastically reduces the poweroff time.