### PR TITLE
fix: remove apx-vso-pico autostart

### DIFF
--- a/includes.container/etc/systemd/user/apx-vso-pico.service
+++ b/includes.container/etc/systemd/user/apx-vso-pico.service
@@ -1,18 +1,16 @@
 [Unit]
-Description=VSO Pico Container
-Wants=network-online.target
-After=network-online.target
+Description=Podman container-apx-vso-pico.service
+Documentation=man:podman-generate-systemd(1)
+PartOf=graphical-session.target
+Requires=podman.service
+Wants=graphical-session.target
+After=graphical-session.target
 
 [Service]
-Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=on-failure
 TimeoutStopSec=10
-ExecStart=/.system/usr/bin/podman start apx-vso-pico
-ExecStop=/.system/usr/bin/podman stop  \
-	-t 5 apx-vso-pico
-ExecStopPost=/.system/usr/bin/podman stop  \
-	-t 5 apx-vso-pico
-Type=forking
+RemainAfterExit=yes
+ExecStop=/.system/usr/bin/podman stop -t 3 apx-vso-pico
+ExecStopPost=/.system/usr/bin/podman stop -t 3 apx-vso-pico
 
 [Install]
-WantedBy=default.target
+WantedBy=graphical-session.target

--- a/recipe.yml
+++ b/recipe.yml
@@ -82,6 +82,12 @@ stages:
     - sed 's/Session=/Session=firstsetup/g' -i /usr/share/accountsservice/user-templates/administrator
     - sed 's/Session=/Session=firstsetup/g' -i /usr/share/accountsservice/user-templates/standard
 
+  - name: apx-vso-pico-shutdown-service
+    type: shell
+    commands:
+    - mkdir -p /etc/systemd/user/graphical-session.target.wants/
+    - ln -s /etc/systemd/user/apx-vso-pico.service /etc/systemd/user/graphical-session.target.wants/
+
   - name: gnome-software-setup
     type: shell
     commands:


### PR DESCRIPTION
If the container is started before the user has an internet connection, the container won't be able to connect to the internet until restarted. This commit removes the autostart part, while leaving the shutdown when graphical-session.target is stopped.