### PR TITLE
fix [#124]: adds support for swap from fstab

### DIFF
--- a/includes.container/usr/lib/systemd/system/abroot-mount-fstab.service
+++ b/includes.container/usr/lib/systemd/system/abroot-mount-fstab.service
@@ -5,7 +5,7 @@ Before=graphical.target
 
 [Service]
 Type=oneshot
-ExecStart=/.system/usr/bin/mount -a
+ExecStart=/bin/bash -c '/usr/bin/mount -a ; /usr/sbin/swapon -a'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Since the user fstab file is loaded after systemd has started, new swap entries are ignored.
This adds a manual swapon call to when the user fstab file is available.

Fixes #124 
