### PR TITLE
feat: add module for GNOME 46 components

### DIFF
--- a/modules/41-gnome-46.yml
+++ b/modules/41-gnome-46.yml
@@ -1,0 +1,9 @@
+name: gnome-46
+type: shell
+commands:
+  - apt install -y jq
+  - curl -s https://api.github.com/repos/Vanilla-OS/debian-gnome-debs/releases/latest | jq .assets[].browser_download_url? | xargs -I'{}' wget {}
+  - apt install -y ./*.deb
+  - rm *mutter*.deb
+  - rm *gnome*.deb
+  - apt remove -y jq

--- a/recipe.yml
+++ b/recipe.yml
@@ -56,6 +56,7 @@ stages:
       - modules/21-gnome-control-center.yml
       - modules/30-gnome-essentials.yml
       - modules/40-gnome-appearance.yml
+      - modules/41-gnome-46.yml
       - modules/50-laptop-goodies.yml
       - modules/60-media.yml
       - modules/80-printers.yml


### PR DESCRIPTION
Tempfix: Add module to pull gnome components from Debian experimental.

~~This is currently hardcoded while I put together a solution for consistently pulling the same version. Will update the description and remove the draft status when I have that implemented.~~ We are now using the snapshots of packages from the releases of https://github.com/Vanilla-OS/debian-gnome-debs.

This PR:
- Adds modules for gnome 46
- Updates recipe.yml for new module

closes #132