### PR TITLE
fix:[close #133] Add plugins dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Containerfile
 sources/
 downloads/
+plugins/


### PR DESCRIPTION
Adds `plugins` dir to `.gitignore` as that should be excluded from VCS