### PR TITLE
feat: a service for vso tasks rotation

### DIFF
--- a/includes.container/usr/lib/systemd/user/vso-tasks-rotation.service
+++ b/includes.container/usr/lib/systemd/user/vso-tasks-rotation.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=VSO Tasks Rotation
+
+[Service]
+ExecStart=/usr/bin/vso tasks rotate
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/00-vanilla-system-operator.yml
+++ b/modules/00-vanilla-system-operator.yml
@@ -35,6 +35,11 @@ modules:
     packages:
     - dpkg-dev
     - ifstat
+- name: vso-tasks-rotation-autostart
+  type: shell
+  commands: 
+  - mkdir /usr/lib/systemd/user/default.target.wants
+  - ln -s /usr/lib/systemd/user/vso-tasks-rotation.service /usr/lib/systemd/user/default.target.wants/vso-tasks-rotation.service
 - name: adwdialog
   type: dpkg-buildpackage
   source:


### PR DESCRIPTION
closes #136 

This removes the need for creating a autostart file directly into the home directory with vanilla system operator

https://github.com/Vanilla-OS/vanilla-system-operator/blob/05757fb763d43645db2c6ce8b4796f831f928318/core/tasks.go#L271-L303