### PR TITLE
fix[close #141]: Core dumps gets stored in random places

### DIFF
--- a/includes.container/etc/sysctl.d/core-pattern.conf
+++ b/includes.container/etc/sysctl.d/core-pattern.conf
@@ -1,0 +1,1 @@
+kernel.core_pattern = /var/tmp/core.%e.%p.%h.%t


### PR DESCRIPTION
closes #141 

Tested locally with the following steps:

**/etc/sysctl.d/core-pattern.conf**
```
kernel.core_pattern = /var/tmp/core.%e.%p.%h.%t
```

**reload params**
```
sysctl --system
```

**crash.c**
```c
#include <stdio.h>
#include <stdlib.h>

int main() {
    int *ptr = NULL;
    *ptr = 42;
    return 0;
```

**run the crasher**
```
gcc -o crash crash.c
```

**check for dumps in /var/tmp/core**