### PR TITLE
adapts fswarn script to new init system

### DIFF
--- a/includes.container/usr/share/init.d/010-fsguard.sh
+++ b/includes.container/usr/share/init.d/010-fsguard.sh
@@ -35,4 +35,3 @@ function failed() {
 if [[ $? -ne 0 ]]; then
     failed
 fi
-exec /usr/lib/systemd/systemd "$@"

--- a/recipe.yml
+++ b/recipe.yml
@@ -118,7 +118,7 @@ stages:
         commands:
           - rm -rf /FsGuard
           - rm -f ./minisign.pub ./minisign.key
-          - chmod +x /usr/sbin/init
+          - chmod +x /usr/share/init.d/010-fsguard.sh
 
   - name: cleanup2
     type: shell


### PR DESCRIPTION
This PR depends on this: https://github.com/Vanilla-OS/core-image/pull/57
This adjust the FsWarn init system for the new structure.
