### PR TITLE
feat[close #169]: pre-run vso shell at boot if already initialized

### DIFF
--- a/includes.container/usr/bin/wait-for-connection
+++ b/includes.container/usr/bin/wait-for-connection
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+is_network_online() {
+    nmcli -t g | grep -q "connected"
+    return $?
+}
+
+retry_count=0
+max_retries=30
+
+until is_network_online; do
+    if [ $retry_count -ge $max_retries ]; then
+        echo "Network not available after 1 minute. Exiting."
+        exit 1
+    fi
+    echo "Waiting for network..."
+    sleep 2
+    ((retry_count++))
+done
+
+echo "Network is online."

--- a/includes.container/usr/lib/systemd/user/vso-pre-run.service
+++ b/includes.container/usr/lib/systemd/user/vso-pre-run.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=VSO Shell Pre-Run
+
+[Service]
+ExecStartPre=/usr/bin/wait-for-connection
+ExecStart=/usr/bin/vso run -n -- ls || true
+Restart=always
+
+[Install]
+WantedBy=default.target

--- a/modules/00-vanilla-system-operator.yml
+++ b/modules/00-vanilla-system-operator.yml
@@ -26,6 +26,10 @@ modules:
   type: shell
   commands:
   - chmod +x /usr/bin/reset-vso
+- name: wait-for-connection
+  type: shell
+  commands:
+  - chmod +x /usr/bin/wait-for-connection
 - name: vso-gnome-ext
   type: shell
   source:
@@ -40,11 +44,6 @@ modules:
     packages:
     - dpkg-dev
     - ifstat
-- name: vso-tasks-rotation-autostart
-  type: shell
-  commands: 
-  - mkdir /usr/lib/systemd/user/default.target.wants
-  - ln -s /usr/lib/systemd/user/vso-tasks-rotation.service /usr/lib/systemd/user/default.target.wants/vso-tasks-rotation.service
 - name: adwdialog
   type: dpkg-buildpackage
   source:
@@ -74,3 +73,6 @@ modules:
   commands:
   - ln -s /usr/lib/systemd/system/vanilla-updates.service /etc/systemd/system/multi-user.target.wants/vanilla-updates.service
   - ln -s /usr/lib/systemd/system/vanilla-updates.timer /etc/systemd/system/timers.target.wants/vanilla-updates.timer
+  - mkdir -p /usr/lib/systemd/user/default.target.wants
+  - ln -s /usr/lib/systemd/user/vso-pre-run.service /usr/lib/systemd/user/default.target.wants/vso-pre-run.service
+  - ln -s /usr/lib/systemd/user/vso-tasks-rotation.service /usr/lib/systemd/user/default.target.wants/vso-tasks-rotation.service


### PR DESCRIPTION
Since user sysd units cannot depend on system targets, I made a custom script that uses `nmcli` to check for the connectivity, then used it as a condition in `ExecStartPre`.

Tested on a VM:
- installed the unit
- restarted the VM
- I noticed that Vso didn't show the distrobox initialization process but the prompt directly