### PR TITLE
feat: add gnome-epub-thumbnailer

### DIFF
--- a/modules/210-libs-extra.yml
+++ b/modules/210-libs-extra.yml
@@ -16,3 +16,4 @@ source:
   - libpam-gnome-keyring
   - libproxy1-plugin-gsettings
   - libwmf0.2-7-gtk
+  - gnome-epub-thumbnailer


### PR DESCRIPTION
This PR adds the `gnome-epub-thumbnailer` package which renders eBook thumbnails in Nautilus.

## References

- https://packages.debian.org/sid/gnome-epub-thumbnailer
- https://www.omgubuntu.co.uk/2024/07/how-to-display-ebook-thumbnails-in-nautilus