### PR TITLE
remove invalid syntax from systemd service

### DIFF
--- a/includes.container/usr/lib/systemd/user/vso-pre-run.service
+++ b/includes.container/usr/lib/systemd/user/vso-pre-run.service
@@ -3,7 +3,7 @@ Description=VSO Shell Pre-Run
 
 [Service]
 ExecStartPre=/usr/bin/wait-for-connection
-ExecStart=/usr/bin/vso run -n -- ls || true
+ExecStart=/usr/bin/vso run -n -- ls
 Restart=always
 
 [Install]


### PR DESCRIPTION
Systemd units don't run inside a shell by default so this can't be used.
I removed it entirely since the ls command should never just through an error without a good reason.

(The systemd service still starts the container but the ls command will through an error because "ls || true" is not a valid command)