### PR TITLE
feat (major): migrate modules for stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+env:
+    REGISTRY_USER: ${{ github.actor }}
+    REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  verify-image:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Verify Base Image Integrity
+      run:
+        gh attestation verify oci://ghcr.io/vanilla-os/core:main --owner Vanilla-OS
+      env:
+        GH_TOKEN: ${{ github.token }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: verify-image
+    permissions:
+      contents: write # Allow actions to create release
+      attestations: write # To create and write attestations
+      id-token: write # Additional permissions for the persistence of the attestations
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: vanilla-os/vib-gh-action@v0.7.4
+        with:
+            recipe: 'recipe.yml'
+            plugins: 'Vanilla-OS/vib-fsguard:v1.5.3'
+
+      - uses: actions/upload-artifact@v4
+        with:
+            name: Containerfile
+            path: Containerfile
+
+      - name: Create Release
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${{ github.ref_name }}" --generate-notes Containerfile
+
+      - name: Attest Release Files
+        id: attest
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'Containerfile'

--- a/modules/00-vanilla-apx-gui.yml
+++ b/modules/00-vanilla-apx-gui.yml
@@ -3,8 +3,7 @@ type: meson
 source:
   type: git
   url: https://github.com/Vanilla-OS/apx-gui
-  branch: main
-  commit: latest
+  tag: v1.0.3
 modules:
 - name: apx-gui-deps-install
   type: apt

--- a/modules/00-vanilla-backgrounds.yml
+++ b/modules/00-vanilla-backgrounds.yml
@@ -1,12 +1,12 @@
 name: vanilla-backgrounds
-type: dpkg-buildpackage
+type: shell
 source:
-  type: git
-  url: https://github.com/Vanilla-OS/vanilla-backgrounds.git
-  branch: main
-  commit: latest
-  paths:
-  - vanilla-backgrounds
+  type: file
+  url: https://github.com/Vanilla-OS/vanilla-backgrounds/releases/download/v1.0.4/vanilla-backgrounds.deb
+  checksum: 212675d521cbe69d8c6547cb134784584dd0491ccb1a05c86c8ddfec161b036f
+commands:
+  - dpkg -i /sources/vanilla-backgrounds/vanilla-backgrounds.deb
+  - apt -y install -f
 modules:
 - name: vanilla-backgrounds-deps-install
   type: apt

--- a/modules/00-vanilla-desktop-base.yml
+++ b/modules/00-vanilla-desktop-base.yml
@@ -1,12 +1,12 @@
 name: desktop-base
-type: dpkg-buildpackage
+type: shell
 source:
-  type: git
-  url: https://github.com/Vanilla-OS/desktop-base.git
-  branch: main
-  commit: latest
-  paths:
-  - desktop-base
+  type: file
+  url: https://github.com/Vanilla-OS/desktop-base/releases/download/v1.0.0/desktop-base.deb
+  checksum: ef12defc7514096b076054f5eaf9ca276bba4757f360a2a097e7f2f31ced6840
+commands:
+  - dpkg -i /sources/desktop-base/desktop-base.deb
+  - apt -y install -f
 modules:
 - name: desktop-base-deps-install
   type: apt

--- a/modules/00-vanilla-first-setup.yml
+++ b/modules/00-vanilla-first-setup.yml
@@ -1,12 +1,12 @@
 name: vanilla-first-setup
-type: dpkg-buildpackage
+type: shell
 source:
-  type: git
-  url: https://github.com/Vanilla-OS/first-setup.git
-  branch: main
-  commit: latest
-  paths:
-  - vanilla-first-setup
+  type: file
+  url: https://github.com/Vanilla-OS/first-setup/releases/download/v2.2.0/vanilla-first-setup_2.2.0_amd64.deb
+  checksum: 2320ebffa72cfce093555c48dfe3cf3e670392262bb03bc7a514a169499ee770
+commands:
+  - dpkg -i /sources/vanilla-first-setup/vanilla-first-setup.deb
+  - apt -y install -f
 modules:
 - name: vanilla-first-setup-deps-install
   type: apt
@@ -18,6 +18,7 @@ modules:
     - dpkg-dev
     - gettext
     - gir1.2-nma4-1.0
+    - gir1.2-vte-3.91
     - libadwaita-1-dev
     - libjpeg-dev
     - libnm0

--- a/modules/00-vanilla-gnome-default-settings.yml
+++ b/modules/00-vanilla-gnome-default-settings.yml
@@ -1,12 +1,12 @@
 name: vanilla-gnome-default-settings
-type: dpkg-buildpackage
+type: shell
 source:
-  type: git
-  url: https://github.com/Vanilla-OS/vanilla-gnome-default-settings.git
-  branch: main
-  commit: latest
-  paths:
-  - vanilla-gnome-default-settings
+  type: file
+  url: https://github.com/Vanilla-OS/vanilla-gnome-default-settings/releases/download/v0.1/vanilla-gnome-default-settings.deb
+  checksum: 96d43a5c33673c315e67b317fbd62bba41cb8fd245c45b7036a88d8597f42b93
+commands:
+  - dpkg -i /sources/vanilla-gnome-default-settings/vanilla-gnome-default-settings.deb
+  - apt -y install -f
 modules:
 - name: vanilla-gnome-default-settings-deps-install
   type: apt

--- a/modules/00-vanilla-sideload.yml
+++ b/modules/00-vanilla-sideload.yml
@@ -1,12 +1,9 @@
 name: vanilla-sideload
-type: dpkg-buildpackage
+type: meson
 source:
   type: git
   url: https://github.com/Vanilla-OS/sideload-utility
-  branch: main
-  commit: latest
-  paths:
-  - vanilla-sideload
+  tag: v1.0.0
 modules:
 - name: sideload-utility-deps-install
   type: apt

--- a/modules/00-vanilla-system-operator.yml
+++ b/modules/00-vanilla-system-operator.yml
@@ -2,8 +2,8 @@ name: vso
 type: shell
 source:
   type: tar
-  # switch to production build once in production
-  url: https://github.com/Vanilla-OS/vanilla-system-operator/releases/download/continuous/vso.tar.gz
+  url: https://github.com/Vanilla-OS/vanilla-system-operator/releases/download/v2.0.3/vso.tar.gz
+  checksum: 63673c9f76e41b17623c2b5676dc80c8125512d381ac0ef9a45b9b5aa0bc4b69
 commands:
 - mkdir -p /usr/bin
 - cp /sources/vso/vso /usr/bin/vso
@@ -13,23 +13,28 @@ modules:
   type: shell
   source:
     type: tar
-    url: https://github.com/Vanilla-OS/vanilla-system-operator/releases/download/continuous/vso-man.tar.gz
+    url: https://github.com/Vanilla-OS/vanilla-system-operator/releases/download/v2.0.3/vso-man.tar.gz
+    checksum: d38b5930ccae7880e9d195c709cf9480690a42900b3d2e7c603b1efb3cf3beea
   commands:
   - mv /sources/vso-manpage/man/vso.1 /usr/share/man/man1/
+
 - name: vso-os-shell
   type: shell
   commands:
   - chmod +x /usr/bin/vso-os-shell
   - echo "/usr/bin/vso-os-shell" >> /etc/shells
   - sed -i 's/^\(SHELL=\).*/\1\/usr\/bin\/vso-os-shell/' /etc/default/useradd
+
 - name: reset-vso
   type: shell
   commands:
   - chmod +x /usr/bin/reset-vso
+
 - name: wait-for-connection
   type: shell
   commands:
   - chmod +x /usr/bin/wait-for-connection
+
 - name: vso-gnome-ext
   type: shell
   source:
@@ -38,21 +43,20 @@ modules:
   commands:
   - mkdir -p /usr/share/gnome-shell/extensions/
   - mv /sources/vso-gnome-ext/vso-gnome-ext-1.2/vso\@vanillaos.org /usr/share/gnome-shell/extensions/vso\@vanillaos.org
+
 - name: vso-deps-install
   type: apt
   source:
     packages:
     - dpkg-dev
     - ifstat
+
 - name: adwdialog
-  type: dpkg-buildpackage
+  type: meson
   source:
     type: git
     url: https://github.com/Vanilla-OS/AdwDialog.git
-    branch: main
-    commit: latest
-    paths:
-    - adwdialog
+    tag: v0.2.0
   modules:
   - name: adwdialog-deps-install
     type: apt
@@ -68,6 +72,7 @@ modules:
       - make
       - meson
       - python3
+
 - name: enable-systemd-unit
   type: shell
   commands:

--- a/modules/00-vanilla-tour.yml
+++ b/modules/00-vanilla-tour.yml
@@ -1,12 +1,10 @@
 name: vanilla-tour
-type: dpkg-buildpackage
+type: meson
 source:
   type: git
   url: https://github.com/Vanilla-OS/vanilla-tour
   branch: main
-  commit: latest
-  paths:
-  - vanilla-tour
+  tag: v0.0.1
 modules:
 - name: vanilla-tour-deps-install
   type: apt

--- a/modules/00-vanilla-updates-utility.yml
+++ b/modules/00-vanilla-updates-utility.yml
@@ -3,8 +3,7 @@ type: meson
 source:
   type: git
   url: https://github.com/Vanilla-OS/vanilla-updates-utility
-  branch: main
-  commit: latest
+  tag: v1.0.1
 modules:
 - name: vanilla-updates-utility-deps-install
   type: apt

--- a/modules/02-waydroid-modules.yml
+++ b/modules/02-waydroid-modules.yml
@@ -7,9 +7,8 @@ commands:
 - dkms install waydroid-ashmem/1 -k $(ls /usr/src | grep -Po '[0-9].[0-9].[0-9].*$' | head -1)
 source:
   type: git
-  url: https://github.com/choff/anbox-modules.git
-  branch: master
-  commit: latest
+  url: https://github.com/Vanilla-OS/anbox-modules
+  tag: v1.0.0
 modules:
   - name: waydroid-deps-install
     type: apt

--- a/modules/10-vanilla-abroot-rollback-notifier.yml
+++ b/modules/10-vanilla-abroot-rollback-notifier.yml
@@ -3,8 +3,7 @@ type: meson
 source:
   type: git
   url: https://github.com/Vanilla-OS/abroot-rollback-notifier
-  branch: main
-  commit: latest
+  tag: v1.0.0
 modules:
 - name: abroot-rollback-notifier-deps-install
   type: apt

--- a/modules/131-plymouth-theme-vanilla.yml
+++ b/modules/131-plymouth-theme-vanilla.yml
@@ -1,12 +1,30 @@
-name: plymouth-theme-vanilla
-type: dpkg-buildpackage
+name: plymouth-theme-vanilla-bgrt
+type: shell
 source:
-  type: git
-  url: https://github.com/Vanilla-OS/plymouth-theme-vanilla
-  branch: main
-  commit: latest
-  paths:
-  - plymouth-theme-vanilla
-  - plymouth-theme-vanilla-bgrt
-  - plymouth-theme-vanilla-logo
-  - plymouth-theme-vanilla-text
+  type: file
+  url: https://github.com/Vanilla-OS/plymouth-theme-vanilla/releases/download/v1.0.0/plymouth-theme-vanilla-bgrt.deb
+  checksum: 63fdfe0e87c77ff6ce6253f2c975ab9dd3089849df76fa53a7ba8567e141886c
+commands:
+  - dpkg -i /sources/plymouth-theme-vanilla-bgrt/plymouth-theme-vanilla-bgrt.deb
+  - apt -y install -f
+
+modules:
+  - name: plymouth-theme-vanilla-logo
+    type: shell
+    source:
+      type: file
+      url: https://github.com/Vanilla-OS/plymouth-theme-vanilla/releases/download/v1.0.0/plymouth-theme-vanilla-logo.deb
+      checksum: 031d418d89011c515b40fdbfba312c314f1d782537164cbe1a1787d0011695dc
+    commands:
+      - dpkg -i /sources/plymouth-theme-vanilla-logo/plymouth-theme-vanilla-logo.deb
+      - apt -y install -f
+
+  - name: plymouth-theme-vanilla-text
+    type: shell
+    source:
+      type: file
+      url: https://github.com/Vanilla-OS/plymouth-theme-vanilla/releases/download/v1.0.0/plymouth-theme-vanilla-text.deb
+      checksum: fbeaca1b0d4f490ab0b0801552333eaa41683e0806084f2ab2cdea019125eb60
+    commands:
+      - dpkg -i /sources/plymouth-theme-vanilla-text/plymouth-theme-vanilla-text.deb
+      - apt -y install -f

--- a/modules/170-gnome-software-vso-plugin.yml
+++ b/modules/170-gnome-software-vso-plugin.yml
@@ -1,5 +1,9 @@
-name: gs-vso-plugin
+name: libgs_plugin_vso
 type: shell
+source:
+  type: file
+  url: https://github.com/Vanilla-OS/gs-plugin-vso/releases/download/v1.0.0/libgs_plugin_vso.so
+  checksum: ac9c6a95a2665b084ab3a0d962c35a1f2933bcf43859b1cd46cca2a8104698e4
 commands:
-- curl -L -O https://github.com/Vanilla-OS/gs-plugin-vso/releases/download/continuous/libgs_plugin_vso.so
-- mv libgs_plugin_vso.so /usr/lib/x86_64-linux-gnu/gnome-software/plugins-20/
+    - mkdir -p /usr/lib
+    - cp /sources/libgs_plugin_vso/libgs_plugin_vso.so /usr/lib/x86_64-linux-gnu/gnome-software/plugins-20/

--- a/modules/21-gnome-control-center.yml
+++ b/modules/21-gnome-control-center.yml
@@ -2,9 +2,10 @@ name: gnome-control-center
 type: shell
 source:
   type: tar
-  url: https://github.com/Vanilla-OS/gnome-control-center/releases/download/continuous/gnome-control-center.tar.xz
+  url: https://github.com/Vanilla-OS/gnome-control-center/releases/download/v1.0.1/gnome-control-center.tar.xz
+  checksum: 669a3bd81e1716df0600a0b5b33862a69cddfd3d7ff960d891aa0ebacb3c5d1e
 commands:
-  - dpkg -i /sources/gnome-control-center/gnome-control-center-data_46~99-orchid-beta_all.deb 
-  - dpkg -i /sources/gnome-control-center/gnome-control-center_46~99-orchid-beta_amd64.deb
+  - dpkg -i /sources/gnome-control-center/gnome-control-center-data_46~99-orchid-stable_all.deb 
+  - dpkg -i /sources/gnome-control-center/gnome-control-center_46~99-orchid-stable_amd64.deb
   - apt -y install -f
   - apt-mark hold gnome-control-center

--- a/recipe.yml
+++ b/recipe.yml
@@ -29,8 +29,8 @@ stages:
     type: shell
     source:
       type: tar
-      # switch to production build once in production
-      url: https://github.com/Vanilla-OS/vanilla-tools/releases/download/continuous/vanilla-tools.tar.gz
+      url: https://github.com/Vanilla-OS/vanilla-tools/releases/download/v1.0.0/vanilla-tools.tar.gz
+      checksum: 0e1d92d9c9154f9a115e97b40ff692afa52ddd0d9f770a8ec67440bf1a48aa72
     commands:
     - mkdir -p /usr/bin
     - cp /sources/vanilla-tools/vanilla-tools/lpkg /usr/bin/lpkg


### PR DESCRIPTION
This PR performs major changes making the desktop image ready for the 28th stable release.

## Changes

- Migrate Git sources to tagged releases.
- Migrate Tar sources to tagged releases with checksum verification.
- Replace a few Dpkg modules to use pre-build DEBs from release assets fetched using the file source type along with checksum verification.

## Checklist

- [x] Adapt modules to the above changes.
- [x] Add release workflow similar to other image workflows.
- [x] Test build and squash commits once it succeeds.