### PR TITLE
fix: add dep, bump packages

### DIFF
--- a/modules/00-vanilla-first-setup.yml
+++ b/modules/00-vanilla-first-setup.yml
@@ -3,7 +3,7 @@ type: dpkg-buildpackage
 source:
   type: git
   url: https://github.com/Vanilla-OS/first-setup.git
-  tag: v2.2.0
+  tag: v2.2.1
   paths:
   - vanilla-first-setup
 modules:

--- a/modules/131-plymouth-theme-vanilla.yml
+++ b/modules/131-plymouth-theme-vanilla.yml
@@ -3,7 +3,7 @@ type: dpkg-buildpackage
 source:
   type: git
   url: https://github.com/Vanilla-OS/plymouth-theme-vanilla
-  tag: v1.0.0
+  tag: v1.0.1
   paths:
   - plymouth-theme-vanilla
   - plymouth-theme-vanilla-bgrt

--- a/modules/210-libs-extra.yml
+++ b/modules/210-libs-extra.yml
@@ -11,6 +11,7 @@ source:
   - ibus-gtk4
 
   - libgdk-pixbuf2.0-bin
+  - libjxl-gdk-pixbuf
   - libglib2.0-bin
   - libblockdev-crypto3
   - libpam-gnome-keyring


### PR DESCRIPTION
## Changes

- Bump first setup version to use the new logo.
- Bump Plymouth version to get the recent fix from Tau.
- Add JPEG-XL pixbuf dep because GNOME backgrounds are in that format but the Debian package doesn't list/install it as a dep.

Post the change the solid backgrounds (non-SVG, PNG ones) will be fixed and it will be something like:

![image](https://github.com/user-attachments/assets/97dfcddf-6a46-47f4-8626-38a087cc1470)
