### PR TITLE
Consider adding python3-nautilus (nautilus extensions support)

### DIFF
--- a/modules/30-gnome-essentials.yml
+++ b/modules/30-gnome-essentials.yml
@@ -4,6 +4,7 @@ source:
   packages:
   - nautilus
   - nautilus-share
+  - python3-nautilus
 
   - gnome-bluetooth
   - gnome-color-manager


### PR DESCRIPTION
This package is needed to allow extensions to run on nautilus