### PR TITLE
chore: downgrade first-setup to v2.2.1

### DIFF
--- a/modules/00-vanilla-first-setup.yml
+++ b/modules/00-vanilla-first-setup.yml
@@ -3,7 +3,7 @@ type: dpkg-buildpackage
 source:
   type: git
   url: https://github.com/Vanilla-OS/first-setup.git
-  tag: v2.2.2
+  tag: v2.2.1
   paths:
   - vanilla-first-setup
 modules:


### PR DESCRIPTION
Due to a bug introduced in version 2.2.2, the first user created during the first setup, cannot proceed with the configuration.