### PR TITLE
removes polkit rule for security reasons

### DIFF
--- a/includes.container/usr/share/polkit-1/rules.d/org.vanillaos.vso.rules
+++ b/includes.container/usr/share/polkit-1/rules.d/org.vanillaos.vso.rules
@@ -2,9 +2,7 @@ polkit.addRule(function (action, subject) {
   if (
     (
       action.id == "org.vanillaos.vso.sys" ||
-      action.id == "org.vanillaos.vso.sys-upgrade" ||
-      action.id == "org.vanillaos.vso.distrobox" ||
-      action.id == "org.vanillaos.vso.podman"
+      action.id == "org.vanillaos.vso.sys-upgrade"
     ) &&
     subject.isInGroup("sudo")
   ) {


### PR DESCRIPTION
Podman can be used to aquire full access to the root user so unrestricted access is dangerous.