### PR TITLE
adjust workflows to new branch structure 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Change tag in recipe.
+        run: |
+          sed 's/ghcr.io\/vanilla-os\/core:dev/ghcr.io\/vanilla-os\/core:main/' -i recipe.yml
+
       - uses: vanilla-os/vib-gh-action@v0.7.4
         with:
             recipe: 'recipe.yml'

--- a/.github/workflows/sync-main.yml
+++ b/.github/workflows/sync-main.yml
@@ -1,0 +1,36 @@
+name: Sync Main Branch
+
+on:
+  workflow_dispatch:
+
+jobs:
+  check_base_status:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone base image. 
+      uses: actions/checkout@v4
+      with:
+        repository: Vanilla-OS/core-image
+
+    - name: Check if base is up to date.
+      run: |
+        git fetch origin
+        main_head=$( git rev-parse origin/main )
+        dev_head=$( git rev-parse origin/dev )
+        echo main branch is at: $main_head
+        echo dev branch is at: $dev_head
+        [ "$main_head" = "$dev_head" ]
+
+  sync:
+    runs-on: ubuntu-latest
+    needs: check_base_status
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Push dev to main.
+        run: |
+          git push origin dev:main

--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - 'dev'
-    tags:
-      - '*'
   workflow_dispatch:
   pull_request:
 
@@ -18,6 +16,7 @@ jobs:
 
     steps:
     - name: Verify Base Image Integrity
+      if: ${{ github.ref == 'refs/heads/main' }}
       run:
         gh attestation verify oci://ghcr.io/vanilla-os/core:main --owner Vanilla-OS
       env:
@@ -34,6 +33,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Change tag in recipe.
+      if: ${{ github.ref == 'refs/heads/main' }}
+      run: |
+        sed 's/ghcr.io\/vanilla-os\/core:dev/ghcr.io\/vanilla-os\/core:main/' -i recipe.yml
 
     - uses: vanilla-os/vib-gh-action@v0.7.4
       with:


### PR DESCRIPTION
The changes make it possible to build main with the Vib Workflow by automatically changing the :dev tag to :main during building.

They also add a workflow to easily sync the main branch with the dev branch on demand, while checking if core image is up to date as well.

When this is trough, I will add these changes to the other images as well.