### PR TITLE
fix:[close #183] Restrict differ to dev branch only

### DIFF
--- a/.github/workflows/differ.yml
+++ b/.github/workflows/differ.yml
@@ -3,6 +3,7 @@ name: Differ
 on:
   workflow_run:
     workflows: [Vib Build]
+    branches: [dev]
     types:
       - completed
 
@@ -10,7 +11,7 @@ jobs:
   differ:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vanilla-os/desktop:main
+      image: ghcr.io/vanilla-os/desktop:${{ github.ref_name }}
     if: github.repository == 'vanilla-os/desktop-image'
 
     steps:


### PR DESCRIPTION
- Add branches definition to differ workflow
- Image tag now pulls using the branch name

Tested [here](github.com/jardon/desktop-image/actions) on commit `0e4c7ce`

closes #183 