### PR TITLE
fix: disable smartcard authentication on gdm3

### DIFF
--- a/includes.container/etc/gdm3/greeter.conf.d/1-disable-smartcard-login.conf
+++ b/includes.container/etc/gdm3/greeter.conf.d/1-disable-smartcard-login.conf
@@ -1,0 +1,2 @@
+[org/gnome/login-screen]
+enable-smartcard-authentication=false


### PR DESCRIPTION
Disables smartcard authentication in gdm3 by default which is an issue for users with yubikeys or similar smartcards.

The feature is only useful for corporate networks, which Vanilla OS isn't targeting currently and which would create unique images either way

https://gitlab.gnome.org/GNOME/gdm/-/issues/877