### PR TITLE
fix: update meson install prefix

### DIFF
--- a/modules/00-vanilla-apx-gui.yml
+++ b/modules/00-vanilla-apx-gui.yml
@@ -1,5 +1,7 @@
 name: apx-gui
 type: meson
+buildflags:
+  - --prefix=/usr
 source:
   type: git
   url: https://github.com/Vanilla-OS/apx-gui

--- a/modules/00-vanilla-updates-utility.yml
+++ b/modules/00-vanilla-updates-utility.yml
@@ -1,5 +1,7 @@
 name: vanilla-updates-utility
 type: meson
+buildflags:
+  - --prefix=/usr
 source:
   type: git
   url: https://github.com/Vanilla-OS/vanilla-updates-utility

--- a/modules/10-vanilla-abroot-rollback-notifier.yml
+++ b/modules/10-vanilla-abroot-rollback-notifier.yml
@@ -1,5 +1,7 @@
 name: abroot-rollback-notifier
 type: meson
+buildflags:
+  - --prefix=/usr
 source:
   type: git
   url: https://github.com/Vanilla-OS/abroot-rollback-notifier


### PR DESCRIPTION
- add buildflag to set install prefix for apx-gui
- add buildflag to set install prefix for vanilla-updates-utility
- add buildflag to set install prefix for abroot-rollback-notifier

this will require a new vib release 

closes #175 