### PR TITLE
fix [#192]: disables FSGuard on unclean systems

### DIFF
--- a/includes.container/usr/share/init.d/010-fsguard.sh
+++ b/includes.container/usr/share/init.d/010-fsguard.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+PACKAGES=/usr/share/abroot/package-summary
+if [ -s "$PACKAGES" ]; then
+    echo "image not clean due to abroot pkg, skipping FSGuard"
+    exit 0
+fi
+
 function failed() {
     /.system/usr/bin/plymouth quit
     local squashfs="/.system/boot/fswarn.squash"


### PR DESCRIPTION
When the user uses the abroot pkg functionality, the image that's being used is unclean, so it can not be properly checked with FSGuard.

Fixes #192 