### PR TITLE
fixes nautilus open in shell

### DIFF
--- a/includes.container/usr/share/glib-2.0/schemas/90-nautilus-terminal-rightclick.gschema.override
+++ b/includes.container/usr/share/glib-2.0/schemas/90-nautilus-terminal-rightclick.gschema.override
@@ -1,3 +1,4 @@
 [com.github.stunkymonkey.nautilus-open-any-terminal]
-terminal = blackbox
+terminal = custom
+custom-local-command = blackbox-terminal -w %s
 use-generic-terminal-name = true


### PR DESCRIPTION
the nautilus extension assumes that the executable of blackbox is "blackbox", but for us it's "blackbox-terminal"