### PR TITLE
Fix [#52]: creates override for the gnome accent color

### DIFF
--- a/includes.container/usr/share/glib-2.0/schemas/90-gnome-accent-color.gschema.override
+++ b/includes.container/usr/share/glib-2.0/schemas/90-gnome-accent-color.gschema.override
@@ -1,0 +1,2 @@
+[org.gnome.desktop.interface]
+accent-color = "yellow"


### PR DESCRIPTION
This sets the default accent color to yellow to fit the VOS look better.
The user can still change this color in the control center.

Tested in a VM.

Fixes #52 
