### PR TITLE
hides imagemagick desktop entry

### DIFF
--- a/modules/300-hide-image-magick.yml
+++ b/modules/300-hide-image-magick.yml
@@ -1,0 +1,4 @@
+name: hide-image-magick
+type: shell
+commands:
+- sed -i '/^Categories=/ s/$/Utility;X-GNOME-Utilities;/' /usr/share/applications/display-im7.q16.desktop

--- a/recipe.yml
+++ b/recipe.yml
@@ -74,6 +74,7 @@ stages:
       - modules/170-gnome-software-vso-plugin.yml
       - modules/200-gnome-common.yml
       - modules/210-libs-extra.yml
+      - modules/300-hide-image-magick.yml
       - modules/997-ensure-exec-hooks.yml
       - modules/998-vanilla-cleanup.yml
       - modules/999-pkg-cleanup.yml


### PR DESCRIPTION
Since ooo-thumbnailer depends on imagemagick, we can't just remove it so the best thing to do is just hide the desktop entry.