### PR TITLE
fix: DKMS requiring manual version updates in waydroid module

### DIFF
--- a/modules/02-waydroid-modules.yml
+++ b/modules/02-waydroid-modules.yml
@@ -3,8 +3,8 @@ type: shell
 commands:
 - cp -rT /sources/waydroid-modules/binder /usr/src/waydroid-binder-1
 - cp -rT /sources/waydroid-modules/ashmem /usr/src/waydroid-ashmem-1
-- dkms install waydroid-binder/1 -k 6.11.6-amd64
-- dkms install waydroid-ashmem/1 -k 6.11.6-amd64
+- dkms install waydroid-binder/1 -k $(cat /usr/share/vanilla/kernel-version)
+- dkms install waydroid-ashmem/1 -k $(cat /usr/share/vanilla/kernel-version)
 source:
   type: git
   url: https://github.com/Vanilla-OS/anbox-modules


### PR DESCRIPTION
This PR is fairly self explanatory. Honestly, I don't know why this is structured as it is in the first place.