### PR TITLE
fix [#232]: don't block boot because of nmbd service

### DIFF
--- a/modules/31-nmbd-service-patch.yml
+++ b/modules/31-nmbd-service-patch.yml
@@ -1,0 +1,4 @@
+name: nmbd-service-patch
+type: shell
+commands:
+- sed -i 's/Type=notify/Type=simple/g' /usr/lib/systemd/system/nmbd.service

--- a/recipe.yml
+++ b/recipe.yml
@@ -57,6 +57,7 @@ stages:
       - modules/20-gnome-core.yml
       - modules/21-gnome-control-center.yml
       - modules/30-gnome-essentials.yml
+      - modules/31-nmbd-service-patch.yml
       - modules/35-nautilus-terminal-rightclick.yml
       - modules/40-gnome-appearance.yml
       - modules/50-laptop-goodies.yml


### PR DESCRIPTION
This service was delaying the boot for a long time if it couldn't connect to a network.

This is a somewhat dirty solution that just sets the service to "simple" instead of "notify". This means that it won't delay the boot but will still start if it can.

I think this is an acceptable solution for now.

Fixes #232 