### PR TITLE
fix [#256]: uses silent mode for vso

### DIFF
--- a/includes.container/usr/lib/systemd/user/vso-tasks-rotation.service
+++ b/includes.container/usr/lib/systemd/user/vso-tasks-rotation.service
@@ -2,7 +2,7 @@
 Description=VSO Tasks Rotation
 
 [Service]
-ExecStart=/usr/bin/vso tasks rotate
+ExecStart=/usr/bin/vso tasks rotate --silent
 
 [Install]
 WantedBy=multi-user.target

--- a/modules/00-vanilla-system-operator.yml
+++ b/modules/00-vanilla-system-operator.yml
@@ -2,8 +2,8 @@ name: vso
 type: shell
 source:
   type: tar
-  url: https://github.com/Vanilla-OS/vanilla-system-operator/releases/download/v2.0.4/vso.tar.gz
-  checksum: cd65bcfcfcddd6f7095ba5db7a79a23e9d4fcffd11113e372de916b40719570e
+  url: https://github.com/Vanilla-OS/vanilla-system-operator/releases/download/v2.0.5/vso.tar.gz
+  checksum: 04799ddcccb83c2042524f897c0d49d176af9c89a2619061f2f0e6e0e47d7e93
 commands:
 - mkdir -p /usr/bin
 - cp /sources/vso/vso /usr/bin/vso
@@ -13,8 +13,8 @@ modules:
   type: shell
   source:
     type: tar
-    url: https://github.com/Vanilla-OS/vanilla-system-operator/releases/download/v2.0.4/vso-man.tar.gz
-    checksum: ad39ca5b7fb301d102345bfb7e92fd32cdd24f0348fbaae134eeb07eea1c9b4f
+    url: https://github.com/Vanilla-OS/vanilla-system-operator/releases/download/v2.0.5/vso-man.tar.gz
+    checksum: 192c79a83fe24d329379d4961955b895393b23636473fcb2326bbcf6b7638ef4
   commands:
   - mv /sources/vso-manpage/man/vso.1 /usr/share/man/man1/
 


### PR DESCRIPTION
Fixes #256

Depends on: https://github.com/Vanilla-OS/vanilla-system-operator/pull/164

Also needs a new vso version.