### PR TITLE
chore: upgrade First-Setup

### DIFF
--- a/modules/00-vanilla-first-setup.yml
+++ b/modules/00-vanilla-first-setup.yml
@@ -1,31 +1,8 @@
 name: vanilla-first-setup
-type: dpkg-buildpackage
+type: shell
 source:
-  type: git
-  url: https://github.com/Vanilla-OS/first-setup.git
-  tag: v2.2.5
-  paths:
-  - vanilla-first-setup
-modules:
-- name: vanilla-first-setup-deps-install
-  type: apt
-  source:
-    packages:
-    - build-essential
-    - debhelper
-    - desktop-file-utils
-    - dpkg-dev
-    - gettext
-    - gir1.2-nma4-1.0
-    - gir1.2-vte-3.91
-    - libadwaita-1-dev
-    - libjpeg-dev
-    - libnm0
-    - libnm-dev
-    - libnma0
-    - libnma-gtk4-0
-    - libnma-gtk4-dev
-    - make
-    - meson
-    - python3
-    - python3-tz
+  type: file
+  url: https://github.com/Vanilla-OS/first-setup/releases/download/v3.0.0/vanilla-first-setup.deb
+  checksum: 10d12008cd76d79f127f0edc563a07033792abdc44cb65db03832095029bbdaf
+commands:
+  - apt-get install -y /sources/vanilla-first-setup/vanilla-first-setup.deb

--- a/recipe.yml
+++ b/recipe.yml
@@ -81,12 +81,6 @@ stages:
       - modules/999-pkg-cleanup.yml
       - modules/999-clear-first-setup-steps-unit.yml
 
-  - name: firstsetup-default-session
-    type: shell
-    commands:
-    - sed 's/Session=/Session=firstsetup/g' -i /usr/share/accountsservice/user-templates/administrator
-    - sed 's/Session=/Session=firstsetup/g' -i /usr/share/accountsservice/user-templates/standard
-
   - name: blackbox-rescue
     type: shell
     commands:


### PR DESCRIPTION
This upgrades the First-Setup version.
It also switches to a shell module.

The reason why a shell module would be better here is so that we can manage the dependencies completely in the First-Setup repo and don't have to duplicate that here. This avoids broken dependencies on upgrades.