### PR TITLE
fix: use vanilla-shell-detect as SHELL for new users

### DIFF
--- a/modules/00-vanilla-system-operator.yml
+++ b/modules/00-vanilla-system-operator.yml
@@ -18,12 +18,13 @@ modules:
   commands:
   - mv /sources/vso-manpage/man/vso.1 /usr/share/man/man1/
 
-- name: vso-os-shell
+- name: vanilla-shell-detect
   type: shell
   commands:
   - chmod +x /usr/bin/vso-os-shell
-  - echo "/usr/bin/vso-os-shell" >> /etc/shells
-  - sed -i 's/^\(SHELL=\).*/\1\/usr\/bin\/vso-os-shell/' /etc/default/useradd
+  - chmod +x /usr/bin/vanilla-shell-detect
+  - echo "/usr/bin/vanilla-shell-detect" >> /etc/shells
+  - sed -i 's/^\(SHELL=\).*/\1\/usr\/bin\/vanilla-shell-detect/' /etc/default/useradd
 
 - name: reset-vso
   type: shell


### PR DESCRIPTION
It fixes using and booting to GNOME for new users in system