### PR TITLE
removes nautilus-share plugin

### DIFF
--- a/modules/30-gnome-essentials.yml
+++ b/modules/30-gnome-essentials.yml
@@ -3,7 +3,6 @@ type: apt
 source:
   packages:
   - nautilus
-  - nautilus-share
   - python3-nautilus
 
   - gnome-bluetooth-sendto

--- a/modules/31-nmbd-service-patch.yml
+++ b/modules/31-nmbd-service-patch.yml
@@ -1,5 +1,0 @@
-name: nmbd-service-patch
-type: shell
-commands:
-- grep -F "nss-user-lookup.target" /usr/lib/systemd/system/winbind.service
-- sed -i 's/nss-user-lookup.target/nss-lookup.target/g' /usr/lib/systemd/system/winbind.service

--- a/recipe.yml
+++ b/recipe.yml
@@ -57,7 +57,6 @@ stages:
       - modules/20-gnome-core.yml
       - modules/21-gnome-control-center.yml
       - modules/30-gnome-essentials.yml
-      - modules/31-nmbd-service-patch.yml
       - modules/35-nautilus-terminal-rightclick.yml
       - modules/40-gnome-appearance.yml
       - modules/50-laptop-goodies.yml


### PR DESCRIPTION
This plugin didn't work.
Removing it also removes samba, which removes a possible attack vector.