### PR TITLE
fix: disable ssh daemon properly

### DIFF
--- a/modules/121-disable-ssh-daemon.yml
+++ b/modules/121-disable-ssh-daemon.yml
@@ -1,4 +1,4 @@
 name: disable-ssh-daemon
 type: shell
 commands:
-  - unlink /etc/systemd/system/multi-user.target.wants/ssh.service
+  - systemctl disable ssh.service


### PR DESCRIPTION
The SSH service was not being disabled correctly, causing it to appear as enabled in system settings.

The issue occurred because two symlinks needed to be removed:
+ `/etc/systemd/system/ssh.service`
+ `/etc/systemd/system/multi-user.target.wants/ssh.service`

Instead of removing these symlinks manually, this fix uses the proper `systemctl` command to ensure the service is correctly disabled.