### PR TITLE
adds sudo replacement

### DIFF
--- a/includes.container/usr/bin/sudo
+++ b/includes.container/usr/bin/sudo
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec pkexec --keep-cwd "$@"

--- a/modules/997-misc-setup.yml
+++ b/modules/997-misc-setup.yml
@@ -10,3 +10,5 @@ commands:
   - ln -s /usr/lib/systemd/system/fix-gdm-permissions.service /etc/systemd/system/multi-user.target.wants/
   # gnome-software-setup
   - rm /usr/lib/*/gnome-software/plugins-*/libgs_plugin_packagekit.so
+  # make the sudo replacement executable
+  - chmod +x /usr/bin/sudo


### PR DESCRIPTION
This creates a "sudo" command that just runs "pkexec --keep-cwd" in the background for a similar experience.

Having only pkexec on it's own can be problematic, since it runs with working directory /root by default. It can also be confusing to users.

While it would be best to not require the user to use sudo ever, we're sadly just not at that point currently.